### PR TITLE
feat(cli): add @clack/prompts foundation (Phase 1)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,6 +20,7 @@
     "verify": "tsx ./src/index.ts verify"
   },
   "dependencies": {
+    "@clack/prompts": "^0.8.2",
     "@exitbook/balance": "workspace:*",
     "@exitbook/core": "workspace:*",
     "@exitbook/data": "workspace:*",
@@ -27,7 +28,10 @@
     "@exitbook/providers": "workspace:*",
     "@exitbook/shared-logger": "workspace:*",
     "commander": "^14.0.0",
+    "cosmiconfig": "^9.0.0",
+    "detect-package-manager": "^3.0.2",
     "jose": "^6.0.13",
+    "picocolors": "^1.1.1",
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {

--- a/apps/cli/src/lib/exit-codes.ts
+++ b/apps/cli/src/lib/exit-codes.ts
@@ -1,0 +1,54 @@
+/**
+ * Semantic exit codes for the CLI.
+ * Following POSIX conventions and best practices.
+ */
+export const ExitCodes = {
+  /** Successful execution */
+  SUCCESS: 0,
+
+  /** General error (catch-all) */
+  GENERAL_ERROR: 1,
+
+  /** Invalid command arguments or options */
+  INVALID_ARGS: 2,
+
+  /** Authentication or credentials error */
+  AUTHENTICATION_ERROR: 3,
+
+  /** Resource not found (file, address, session, etc.) */
+  NOT_FOUND: 4,
+
+  /** Rate limit exceeded */
+  RATE_LIMIT: 5,
+
+  /** Network or connectivity error */
+  NETWORK_ERROR: 6,
+
+  /** Database error */
+  DATABASE_ERROR: 7,
+
+  /** Validation error (data validation failed) */
+  VALIDATION_ERROR: 8,
+
+  /** Operation cancelled by user */
+  CANCELLED: 9,
+
+  /** Timeout error */
+  TIMEOUT: 10,
+
+  /** Configuration error */
+  CONFIG_ERROR: 11,
+
+  /** Permission denied */
+  PERMISSION_DENIED: 13,
+} as const;
+
+export type ExitCode = (typeof ExitCodes)[keyof typeof ExitCodes];
+
+/**
+ * Exit the process with a specific exit code.
+ * Use this instead of process.exit() for better tracking.
+ */
+export function exitWithCode(code: ExitCode): never {
+  process.exit(code);
+}

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -1,0 +1,190 @@
+import * as p from '@clack/prompts';
+import { getLogger } from '@exitbook/shared-logger';
+import pc from 'picocolors';
+
+import type { CLIResponse } from '../types/cli-response.js';
+import { createErrorResponse, createSuccessResponse, exitCodeToErrorCode } from '../types/cli-response.js';
+
+import { ExitCodes, type ExitCode } from './exit-codes.js';
+
+const logger = getLogger('OutputManager');
+
+export type OutputFormat = 'json' | 'text';
+
+/**
+ * OutputManager handles formatting and displaying CLI output.
+ * Supports both human-readable text output and machine-readable JSON.
+ */
+export class OutputManager {
+  private startTime: number = Date.now();
+
+  constructor(private format: OutputFormat = 'text') {}
+
+  /**
+   * Check if output is in JSON mode.
+   */
+  isJsonMode(): boolean {
+    return this.format === 'json';
+  }
+
+  /**
+   * Check if output is in text mode.
+   */
+  isTextMode(): boolean {
+    return this.format === 'text';
+  }
+
+  /**
+   * Output a success response.
+   */
+  success<T>(command: string, data: T, metadata?: Record<string, unknown>): void {
+    const duration_ms = Date.now() - this.startTime;
+    const response = createSuccessResponse(command, data, {
+      duration_ms,
+      ...metadata,
+    });
+
+    if (this.format === 'json') {
+      console.log(JSON.stringify(response, undefined, 2));
+    } else {
+      this.displayTextSuccess(response);
+    }
+  }
+
+  /**
+   * Output an error response and exit.
+   */
+  error(command: string, error: Error, exitCode: ExitCode = ExitCodes.GENERAL_ERROR): never {
+    const errorCode = exitCodeToErrorCode(exitCode);
+    const response = createErrorResponse(command, error, errorCode);
+
+    if (this.format === 'json') {
+      console.error(JSON.stringify(response, undefined, 2));
+    } else {
+      this.displayTextError(error, errorCode);
+    }
+
+    process.exit(exitCode);
+  }
+
+  /**
+   * Display a spinner (only in text mode).
+   */
+  spinner(): ReturnType<typeof p.spinner> | undefined {
+    if (this.format === 'json') {
+      return undefined;
+    }
+    return p.spinner();
+  }
+
+  /**
+   * Display an intro message (only in text mode).
+   */
+  intro(message: string): void {
+    if (this.format === 'text') {
+      p.intro(pc.bgCyan(pc.black(` ${message} `)));
+    }
+  }
+
+  /**
+   * Display an outro message (only in text mode).
+   */
+  outro(message: string): void {
+    if (this.format === 'text') {
+      p.outro(pc.green(message));
+    }
+  }
+
+  /**
+   * Display a note (only in text mode).
+   */
+  note(message: string, title?: string): void {
+    if (this.format === 'text') {
+      p.note(message, title);
+    }
+  }
+
+  /**
+   * Display a log message (only in text mode).
+   */
+  log(message: string): void {
+    if (this.format === 'text') {
+      p.log.message(message);
+    }
+  }
+
+  /**
+   * Display a warning (only in text mode).
+   */
+  warn(message: string): void {
+    if (this.format === 'text') {
+      p.log.warn(pc.yellow(message));
+    } else {
+      // In JSON mode, warnings go to stderr as structured logs
+      logger.warn(message);
+    }
+  }
+
+  /**
+   * Display progress information (only in text mode, goes to stderr in JSON mode).
+   */
+  progress(message: string, current?: number, total?: number): void {
+    if (this.format === 'text') {
+      if (current !== undefined && total !== undefined) {
+        const percentage = Math.round((current / total) * 100);
+        const bar = '█'.repeat(Math.floor(percentage / 5)) + '░'.repeat(20 - Math.floor(percentage / 5));
+        p.log.message(`${message} [${bar}] ${percentage}%`);
+      } else {
+        p.log.message(message);
+      }
+    } else {
+      // In JSON mode, send progress to stderr so it doesn't interfere with JSON output
+      console.error(
+        JSON.stringify({
+          type: 'progress',
+          message,
+          current,
+          total,
+          timestamp: new Date().toISOString(),
+        })
+      );
+    }
+  }
+
+  /**
+   * Display success in text format.
+   */
+  private displayTextSuccess<T>(response: CLIResponse<T>): void {
+    // Override for specific command types
+    // Subclasses or command handlers can customize this
+    logger.info(`Command '${response.command}' completed successfully`);
+  }
+
+  /**
+   * Display error in text format.
+   */
+  private displayTextError(error: Error, code: string): void {
+    p.log.error(`${pc.red('Error')}: ${error.message}`);
+
+    if (code === 'INVALID_ARGS') {
+      p.note('Check your command arguments and try again.\nRun with --help for usage information.', 'Tip');
+    } else if (code === 'AUTHENTICATION_ERROR') {
+      p.note(
+        'Check your API credentials in the .env file or pass them as arguments.\nExample: --api-key YOUR_KEY --api-secret YOUR_SECRET',
+        'How to fix'
+      );
+    } else if (code === 'NOT_FOUND') {
+      p.note('The requested resource was not found.\nDouble-check the name or ID and try again.', 'Tip');
+    } else if (code === 'RATE_LIMIT') {
+      p.note(
+        'You have exceeded the API rate limit.\nWait a few minutes and try again, or configure rate limits in blockchain-explorers.json',
+        'How to fix'
+      );
+    }
+
+    // Show stack trace in development
+    if (process.env.NODE_ENV === 'development' && error.stack) {
+      logger.debug(`Stack trace:\n${error.stack}`);
+    }
+  }
+}

--- a/apps/cli/src/lib/prompts.ts
+++ b/apps/cli/src/lib/prompts.ts
@@ -1,0 +1,367 @@
+import * as p from '@clack/prompts';
+import { ProcessorFactory } from '@exitbook/import';
+import type { ProviderInfo } from '@exitbook/providers';
+import { ProviderRegistry } from '@exitbook/providers';
+
+/**
+ * Reusable prompt helpers for the CLI.
+ */
+
+/**
+ * Check if the operation was cancelled by the user.
+ */
+export function isCancelled<T>(value: T | symbol): value is symbol {
+  return p.isCancel(value);
+}
+
+/**
+ * Handle cancellation by showing a message and exiting.
+ */
+export function handleCancellation(message = 'Operation cancelled'): never {
+  p.cancel(message);
+  process.exit(0);
+}
+
+/**
+ * Prompt for source type (exchange or blockchain).
+ */
+export async function promptSourceType(): Promise<'exchange' | 'blockchain'> {
+  const sourceType = await p.select({
+    message: 'What would you like to import?',
+    options: [
+      { value: 'exchange' as const, label: 'Exchange', hint: 'Kraken, KuCoin, etc.' },
+      { value: 'blockchain' as const, label: 'Blockchain', hint: 'Bitcoin, Ethereum, etc.' },
+    ],
+  });
+
+  if (isCancelled(sourceType)) {
+    handleCancellation();
+  }
+
+  return sourceType;
+}
+
+/**
+ * Prompt for exchange selection.
+ */
+export async function promptExchange(): Promise<string> {
+  const processorFactory = new ProcessorFactory();
+  const exchanges = await processorFactory.getSupportedSources('exchange');
+
+  const exchange = await p.select({
+    message: 'Select an exchange',
+    options: exchanges.map((name) => ({
+      value: name,
+      label: formatExchangeName(name),
+      hint: getExchangeHint(name),
+    })),
+  });
+
+  if (isCancelled(exchange)) {
+    handleCancellation();
+  }
+
+  return exchange;
+}
+
+/**
+ * Prompt for blockchain selection with autocomplete.
+ * Note: @clack/prompts select has built-in filtering when you type.
+ */
+export async function promptBlockchain(): Promise<string> {
+  const processorFactory = new ProcessorFactory();
+  const blockchains = await processorFactory.getSupportedSources('blockchain');
+
+  // Sort blockchains by category and popularity
+  const sortedBlockchains = sortBlockchainsByCategory(blockchains);
+
+  const blockchain = await p.select({
+    message: 'Select a blockchain (type to filter)',
+    options: sortedBlockchains.map((name) => ({
+      value: name,
+      label: formatBlockchainName(name),
+      hint: getBlockchainHint(name),
+    })),
+    maxItems: 10,
+  });
+
+  if (isCancelled(blockchain)) {
+    handleCancellation();
+  }
+
+  return blockchain;
+}
+
+/**
+ * Prompt for provider selection (for blockchain imports).
+ */
+export async function promptProvider(blockchain: string): Promise<string | undefined> {
+  const allProviders = ProviderRegistry.getAllProviders();
+  const blockchainProviders = allProviders.filter((p) => p.blockchain === blockchain);
+
+  if (blockchainProviders.length === 0) {
+    return undefined;
+  }
+
+  if (blockchainProviders.length === 1) {
+    // Only one provider, use it automatically
+    return blockchainProviders[0]!.name;
+  }
+
+  const provider = await p.select({
+    message: `Select a provider for ${formatBlockchainName(blockchain)}`,
+    options: [
+      { value: 'auto', label: 'Auto (try all providers)', hint: 'Recommended' },
+      ...blockchainProviders.map((p) => ({
+        value: p.name,
+        label: p.name,
+        hint: formatProviderCapabilities(p),
+      })),
+    ],
+  });
+
+  if (isCancelled(provider)) {
+    handleCancellation();
+  }
+
+  return provider === 'auto' ? undefined : provider;
+}
+
+/**
+ * Prompt for import method (CSV or API).
+ */
+export async function promptImportMethod(): Promise<'csv' | 'api'> {
+  const method = await p.select({
+    message: 'Import method?',
+    options: [
+      { value: 'csv' as const, label: 'CSV files', hint: 'Import from exported CSV' },
+      { value: 'api' as const, label: 'API', hint: 'Requires API credentials' },
+    ],
+  });
+
+  if (isCancelled(method)) {
+    handleCancellation();
+  }
+
+  return method;
+}
+
+/**
+ * Prompt for CSV directory path.
+ */
+export async function promptCsvDirectory(): Promise<string> {
+  const csvDir = await p.text({
+    message: 'Path to CSV directory:',
+    placeholder: './data/exports',
+    validate: (value) => {
+      if (!value) return 'Please enter a path';
+      if (!value.startsWith('.') && !value.startsWith('/')) return 'Please enter a valid path';
+    },
+  });
+
+  if (isCancelled(csvDir)) {
+    handleCancellation();
+  }
+
+  return csvDir;
+}
+
+/**
+ * Prompt for wallet address.
+ */
+export async function promptWalletAddress(blockchain: string): Promise<string> {
+  const address = await p.text({
+    message: `${formatBlockchainName(blockchain)} wallet address:`,
+    placeholder: getAddressPlaceholder(blockchain),
+    validate: (value) => {
+      if (!value) return 'Please enter a wallet address';
+      // Basic validation - could be more sophisticated per blockchain
+      if (value.length < 10) return 'Invalid wallet address';
+    },
+  });
+
+  if (isCancelled(address)) {
+    handleCancellation();
+  }
+
+  return address;
+}
+
+/**
+ * Prompt for confirmation.
+ */
+export async function promptConfirm(message: string, initialValue = true): Promise<boolean> {
+  const confirmed = await p.confirm({
+    message,
+    initialValue,
+  });
+
+  if (isCancelled(confirmed)) {
+    handleCancellation();
+  }
+
+  return confirmed;
+}
+
+/**
+ * Format exchange name for display.
+ */
+function formatExchangeName(name: string): string {
+  const names: Record<string, string> = {
+    kraken: 'Kraken',
+    kucoin: 'KuCoin',
+    ledgerlive: 'Ledger Live',
+    coinbase: 'Coinbase',
+  };
+  return names[name] || name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+/**
+ * Get exchange hint/description.
+ */
+function getExchangeHint(name: string): string {
+  const hints: Record<string, string> = {
+    kraken: 'CSV or API',
+    kucoin: 'CSV or API',
+    ledgerlive: 'CSV only',
+    coinbase: 'API only',
+  };
+  return hints[name] || '';
+}
+
+/**
+ * Format blockchain name for display.
+ */
+function formatBlockchainName(name: string): string {
+  const names: Record<string, string> = {
+    bitcoin: 'Bitcoin',
+    ethereum: 'Ethereum',
+    'avalanche-c': 'Avalanche C-Chain',
+    'avalanche-p': 'Avalanche P-Chain',
+    'avalanche-x': 'Avalanche X-Chain',
+    polygon: 'Polygon',
+    'arbitrum-one': 'Arbitrum One',
+    'optimism-mainnet': 'Optimism',
+    'base-mainnet': 'Base',
+    bsc: 'BNB Smart Chain',
+    polkadot: 'Polkadot',
+    kusama: 'Kusama',
+    bittensor: 'Bittensor (TAO)',
+    solana: 'Solana',
+    injective: 'Injective',
+  };
+  return (
+    names[name] ||
+    name
+      .split('-')
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ')
+  );
+}
+
+/**
+ * Get blockchain category hint.
+ */
+function getBlockchainHint(name: string): string {
+  // EVM chains
+  if (
+    [
+      'arbitrum-one',
+      'avalanche-c',
+      'base-mainnet',
+      'blast',
+      'bsc',
+      'ethereum',
+      'linea',
+      'mantle',
+      'optimism-mainnet',
+      'polygon',
+      'scroll',
+      'theta',
+      'zksync',
+    ].includes(name)
+  ) {
+    if (name === 'ethereum') return 'EVM • Layer 1';
+    if (['arbitrum-one', 'base-mainnet', 'optimism-mainnet', 'polygon'].includes(name)) return 'EVM • Layer 2';
+    return 'EVM';
+  }
+
+  // Substrate chains
+  if (['astar', 'bittensor', 'kusama', 'moonbeam', 'polkadot'].includes(name)) {
+    if (name === 'polkadot') return 'Substrate • Layer 0';
+    if (name === 'bittensor') return 'Substrate • AI';
+    return 'Substrate';
+  }
+
+  // Cosmos chains
+  if (['cosmos', 'injective', 'osmosis'].includes(name)) {
+    return 'Cosmos SDK';
+  }
+
+  // Others
+  if (name === 'bitcoin') return 'UTXO • Layer 1';
+  if (name === 'solana') return 'High TPS';
+
+  return '';
+}
+
+/**
+ * Sort blockchains by category and popularity.
+ */
+function sortBlockchainsByCategory(blockchains: string[]): string[] {
+  const order = [
+    // Popular Layer 1s first
+    'bitcoin',
+    'ethereum',
+    'solana',
+    // Popular Layer 2s
+    'polygon',
+    'arbitrum-one',
+    'optimism-mainnet',
+    'base-mainnet',
+    // Other EVM chains
+    'avalanche-c',
+    'bsc',
+    // Substrate
+    'polkadot',
+    'kusama',
+    'bittensor',
+    // Cosmos
+    'injective',
+  ];
+
+  const sorted = [...blockchains].sort((a, b) => {
+    const indexA = order.indexOf(a);
+    const indexB = order.indexOf(b);
+
+    if (indexA === -1 && indexB === -1) return a.localeCompare(b);
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+    return indexA - indexB;
+  });
+
+  return sorted;
+}
+
+/**
+ * Get address placeholder for blockchain.
+ */
+function getAddressPlaceholder(blockchain: string): string {
+  if (blockchain === 'bitcoin') return 'bc1q...';
+  if (blockchain === 'ethereum' || blockchain.includes('evm')) return '0x742d35Cc...';
+  if (blockchain === 'solana') return 'DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK';
+  if (blockchain === 'polkadot' || blockchain === 'kusama') return '1...';
+  return 'wallet address';
+}
+
+/**
+ * Format provider capabilities.
+ */
+function formatProviderCapabilities(provider: ProviderInfo): string {
+  const ops = provider.capabilities.supportedOperations || [];
+  const caps: string[] = [];
+  if (ops.includes('getAddressTransactions')) caps.push('txs');
+  if (ops.includes('getAddressBalance')) caps.push('balance');
+  if (ops.includes('getTokenBalances')) caps.push('tokens');
+  return caps.length > 0 ? caps.join(', ') : '';
+}

--- a/apps/cli/src/types/cli-response.ts
+++ b/apps/cli/src/types/cli-response.ts
@@ -1,0 +1,123 @@
+import type { ExitCode } from '../lib/exit-codes.js';
+
+/**
+ * Standardized CLI response format.
+ * Used for both JSON output and internal tracking.
+ */
+export interface CLIResponse<T = unknown> {
+  /** Whether the command executed successfully */
+  success: boolean;
+
+  /** Command that was executed */
+  command: string;
+
+  /** ISO 8601 timestamp of when the response was generated */
+  timestamp: string;
+
+  /** Response data (only present on success) */
+  data?: T;
+
+  /** Error information (only present on failure) */
+  error?:
+    | {
+        /** Machine-readable error code */
+        code: string;
+
+        /** Additional error details (optional) */
+        details?: unknown;
+
+        /** Human-readable error message */
+        message: string;
+
+        /** Stack trace (only in development/verbose mode) */
+        stack?: string | undefined;
+      }
+    | undefined;
+
+  /** Additional metadata about the execution */
+  metadata?:
+    | {
+        /** Additional context */
+        [key: string]: unknown;
+
+        /** Command execution duration in milliseconds */
+        duration_ms?: number | undefined;
+
+        /** CLI version */
+        version?: string | undefined;
+      }
+    | undefined;
+}
+
+/**
+ * Create a success response.
+ */
+export function createSuccessResponse<T>(command: string, data: T, metadata?: Record<string, unknown>): CLIResponse<T> {
+  const response: CLIResponse<T> = {
+    success: true,
+    command,
+    timestamp: new Date().toISOString(),
+    data,
+  };
+
+  if (metadata) {
+    response.metadata = metadata as {
+      [key: string]: unknown;
+      duration_ms?: number | undefined;
+      version?: string | undefined;
+    };
+  }
+
+  return response;
+}
+
+/**
+ * Create an error response.
+ */
+export function createErrorResponse(
+  command: string,
+  error: Error,
+  code: string,
+  details?: unknown
+): CLIResponse<never> {
+  const errorObj: { code: string; details?: unknown; message: string; stack?: string | undefined } = {
+    code,
+    message: error.message,
+  };
+
+  if (details !== undefined) {
+    errorObj.details = details;
+  }
+
+  if (process.env.NODE_ENV === 'development' && error.stack) {
+    errorObj.stack = error.stack;
+  }
+
+  return {
+    success: false,
+    command,
+    timestamp: new Date().toISOString(),
+    error: errorObj,
+  };
+}
+
+/**
+ * Map exit code to error code string.
+ */
+export function exitCodeToErrorCode(exitCode: ExitCode): string {
+  const codes: Record<number, string> = {
+    1: 'GENERAL_ERROR',
+    2: 'INVALID_ARGS',
+    3: 'AUTHENTICATION_ERROR',
+    4: 'NOT_FOUND',
+    5: 'RATE_LIMIT',
+    6: 'NETWORK_ERROR',
+    7: 'DATABASE_ERROR',
+    8: 'VALIDATION_ERROR',
+    9: 'CANCELLED',
+    10: 'TIMEOUT',
+    11: 'CONFIG_ERROR',
+    13: 'PERMISSION_DENIED',
+  };
+  return codes[exitCode] || 'UNKNOWN_ERROR';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^0.8.2
+        version: 0.8.2
       '@exitbook/balance':
         specifier: workspace:*
         version: link:../../packages/balance
@@ -96,9 +99,18 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.1
+      cosmiconfig:
+        specifier: ^9.0.0
+        version: 9.0.0(typescript@5.9.2)
+      detect-package-manager:
+        specifier: ^3.0.2
+        version: 3.0.2
       jose:
         specifier: ^6.0.13
         version: 6.1.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -624,6 +636,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clack/core@0.3.5':
+    resolution: {integrity: sha512-5cfhQNH+1VQ2xLQlmzXMqUoiaH0lRBq9/CLW9lTyMbuKLC3+xEK01tHVvyut++mLOn5urSHmkm6I0Lg9MaJSTQ==}
+
+  '@clack/prompts@0.8.2':
+    resolution: {integrity: sha512-6b9Ab2UiZwJYA9iMyboYyW9yJvAO9V753ZhS+DHKEjZRKAxPPOb7MXXu84lsPFG+vZt6FRFniZ8rXi+zCIw4yQ==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1964,6 +1982,15 @@ packages:
   core-js-compat@3.45.1:
     resolution: {integrity: sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==}
 
+  cosmiconfig@9.0.0:
+    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2060,6 +2087,10 @@ packages:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  detect-package-manager@3.0.2:
+    resolution: {integrity: sha512-8JFjJHutStYrfWwzfretQoyNGoZVW1Fsrp4JO9spa7h/fBfwgTMEIy4/LBzRDGsxwVPHU0q+T9YvwLDJoOApLQ==}
+    engines: {node: '>=12'}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -2092,6 +2123,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3499,6 +3534,9 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -4206,6 +4244,17 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clack/core@0.3.5':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.8.2':
+    dependencies:
+      '@clack/core': 0.3.5
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@colors/colors@1.6.0': {}
 
@@ -5558,6 +5607,15 @@ snapshots:
     dependencies:
       browserslist: 4.26.3
 
+  cosmiconfig@9.0.0(typescript@5.9.2):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5632,6 +5690,10 @@ snapshots:
 
   detect-newline@4.0.1: {}
 
+  detect-package-manager@3.0.2:
+    dependencies:
+      execa: 5.1.1
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -5661,6 +5723,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
@@ -7490,6 +7554,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
Implements Phase 1 of CLI modernization (#84) with @clack/prompts foundation.

Changes:
- Add dependencies: @clack/prompts, picocolors, cosmiconfig, detect-package-manager
- Create lib/exit-codes.ts with semantic exit codes
- Create types/cli-response.ts with standardized response format
- Create lib/output.ts with OutputManager for JSON/text dual formatting
- Create lib/prompts.ts with reusable prompt helpers

Features:
- Interactive prompts with built-in filtering for exchanges/blockchains
- Standardized CLIResponse format for programmatic usage
- OutputManager supports both human-readable and JSON output
- Smart blockchain sorting and categorization
- Provider selection with capability hints

This establishes the foundation for refactoring commands to support:
1. Interactive mode (TTY + no flags)
2. Flag mode (backward compatible)
3. JSON mode (AI/MCP tools with --json flag)

No breaking changes - all existing commands still work as before.

Related: #84